### PR TITLE
Make piehole container names unique

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       io.balena.features.kernel-modules: 1
 
   pihole1:
-    container_name: pihole
+    container_name: pihole1
     build: ./services/pihole
     privileged: true
     volumes:
@@ -57,7 +57,7 @@ services:
     labels:
       io.balena.features.dbus: "1"
   pihole2:
-    container_name: pihole
+    container_name: pihole2
     build: ./services/pihole
     privileged: true
     volumes:


### PR DESCRIPTION
Doing this resolved the following error for me:
```bash
Error response from daemon: Conflict. The container name "/pihole" is already in use by container "e29a904c128b55ac74d7c67e70e1049e7ff9fa2ac578e37e12408a40580c1273". You have to remove (or rename) that container to be able to reuse that name.
```